### PR TITLE
erroradd

### DIFF
--- a/serverv.py
+++ b/serverv.py
@@ -2,6 +2,7 @@ import socket
 import ffmpeg
 import json
 
+
 class VideoProcessor: #動画を変更するクラス
     def __init__(self):
         pass
@@ -52,35 +53,50 @@ class Server:
         self.port = port
         self.processor = VideoProcessor()
 
+    @staticmethod
+    def parse_header(header: bytes) -> dict:
+        json_size = int.from_bytes(header[:16], byteorder='big') # 最初の16バイト
+        media_type_size = int(header[16]) # 次の1バイト
+        payload_size = int.from_bytes(header[17:64], byteorder='big') # 残り47バイト
+        return {
+            "json_size": json_size,
+            "media_type_size": media_type_size,
+            "payload_size": payload_size
+        }
+
     def handle_client(self, conn):
         try:
             header_size = 64
             header = conn.recv(header_size)
             if not header:
                 return
-            
-            data_size = int.from_bytes(header, byteorder='big')
+
+            header_info = self.parse_header(header)
+            json_size = header_info["json_size"]
+            payload_size = header_info["payload_size"]
+
+            # 必要なデータサイズだけを受信し、バッファに保存する
             data = b""
-            while len(data) < data_size:
+            while len(data) < json_size + payload_size:
                 chunk = conn.recv(1024)
                 if not chunk:
                     break
                 data += chunk
 
-            # データを解析して処理
-            # stage2の要件のmediatype, payloadの使い方がわからない
+            # 受信したデータが期待通りのサイズであるかどうかを確認する
+            if len(data) != json_size + payload_size:
+                raise ValueError("Received incomplete data")
 
-            json_size = int.from_bytes(data[:16], byteorder='big')
-            # media_type_size = int.from_bytes(data[16:17], byteorder='big')
-            json_str = data[17:17+json_size].decode()
-            # media_type = data[17+json_size:17+json_size+media_type_size].decode() #メディアタイプ
-            # payload_size = int.from_bytes(data[17+json_size+media_type_size:], byteorder='big')
+            # 以降の処理は変更なし
+            json_data = data[:json_size].decode()
+            print("Received JSON data:", json_data)
 
+            media_data = data[json_size:]
 
-            json_data = json.loads(json_str)
-            command_number = json_data["command_number"]
-            file_name = json_data["file_name"]
-            output_file = json_data["output_file"]
+            json_obj = json.loads(json_data)
+            command_number = json_obj["command_number"]
+            file_name = json_obj["file_name"]
+            output_file = json_obj["output_file"]
 
             if command_number == '1':
                 self.process_video('compress', file_name, output_file)
@@ -97,7 +113,94 @@ class Server:
                 data = f.read()
                 conn.sendall(data)
 
-        #FileがないときにFileNotFoundErrorをしたいができないExceptionの方に行く
+        except FileNotFoundError as e:
+            error_data = {
+                "error_code": 404,
+                "description": "File not found error.",
+                "solution": "Please check the file path and try again."
+            }
+            self.send_error(conn, error_data)
+            print(f"File not found error: {e}")
+
+        except Exception as e:
+            error_data = {
+                "error_code": 500,
+                "description": "An unexpected error occurred.",
+                "solution": "Please try again later."
+            }
+            print(f"Unexpected error occurred: {e}")  # ここで e を定義
+            self.send_error(conn, error_data)
+
+    def send_error(self, conn, error_data):
+        error_json = json.dumps(error_data)
+        conn.sendall(error_json.encode())
+
+
+    def __init__(self, address, port):
+        self.address = address
+        self.port = port
+        self.processor = VideoProcessor()
+
+    @staticmethod
+    def parse_header(header: bytes) -> dict:
+        json_size = int.from_bytes(header[:16], byteorder='big') # 最初の16バイト
+        media_type_size = int(header[16]) # 次の1バイト
+        payload_size = int.from_bytes(header[17:64], byteorder='big') # 残り47バイト
+        return {
+            "json_size": json_size,
+            "media_type_size": media_type_size,
+            "payload_size": payload_size
+        }
+
+    def handle_client(self, conn):
+        try:
+            header_size = 64
+            header = conn.recv(header_size)
+            if not header:
+                return
+
+            header_info = self.parse_header(header)
+            json_size = header_info["json_size"]
+            payload_size = header_info["payload_size"]
+
+            # 必要なデータサイズだけを受信し、バッファに保存する
+            data = b""
+            while len(data) < json_size + payload_size:
+                chunk = conn.recv(1024)
+                if not chunk:
+                    break
+                data += chunk
+
+            # 受信したデータが期待通りのサイズであるかどうかを確認する
+            if len(data) != json_size + payload_size:
+                raise ValueError("Received incomplete data")
+
+            # 以降の処理は変更なし
+            json_data = data[:json_size].decode()
+            media_data = data[json_size:]
+
+            print("Received JSON data:", json_data) 
+
+            json_obj = json.loads(json_data)
+            command_number = json_obj["command_number"]
+            file_name = json_obj["file_name"]
+            output_file = json_obj["output_file"]
+
+            if command_number == '1':
+                self.process_video('compress', file_name, output_file)
+            elif command_number == '2':
+                self.process_video('change_resolution', file_name, output_file)
+            elif command_number == '3':
+                self.process_video('change_aspect_ratio', file_name, output_file)
+            elif command_number == '4':
+                self.process_video('convert_to_audio', file_name, output_file)
+            elif command_number == '5':
+                self.process_video('convert_to_gif', file_name, output_file)
+
+            with open(output_file, "rb") as f:
+                data = f.read()
+                conn.sendall(data)
+
         except FileNotFoundError as e:
             error_data = {
                 "error_code": 404,
@@ -115,12 +218,9 @@ class Server:
             }
             self.send_error(conn, error_data)
             print(f"Unexpected error occurred: {e}")
-
     def send_error(self, conn, error_data):
         error_json = json.dumps(error_data)
         conn.sendall(error_json.encode())
-
-        
 
     def process_video(self, method, input_file, output_file):
         if method == 'compress':


### PR DESCRIPTION
Hayatoさんに言われた
    def parse_header(header: bytes) -> dict:
        json_size = int.from_bytes(header[:16], byteorder='big') # 最初の16バイト
        media_type_size = int(header[16]) # 次の1バイト
        payload_size = int.from_bytes(header[17:64], byteorder='big') # 残り47バイト
        return {
            "json_size": json_size,
            "media_type_size": media_type_size,
            "payload_size": payload_size
        }
の部分を追加してinputfileがないときにerror404がクライアント側に送信されるようにしました。